### PR TITLE
Remove obsolete version

### DIFF
--- a/dev-setup/docker-compose.yml
+++ b/dev-setup/docker-compose.yml
@@ -1,4 +1,3 @@
-version: '3.8'
 services:
   proxy:
     image: nginx:1.23


### PR DESCRIPTION
[The version attribute is obsolete](https://docs.docker.com/reference/compose-file/version-and-name/#version-top-level-element-obsolete) and raises a warning.